### PR TITLE
fix(cmd): Use buffered reads

### DIFF
--- a/git/cmd.py
+++ b/git/cmd.py
@@ -605,6 +605,7 @@ class Git(LazyMixin):
             proc = Popen(command,
                          env=env,
                          cwd=cwd,
+                         bufsize=-1,
                          stdin=istream,
                          stderr=PIPE,
                          stdout=with_stdout and PIPE or None,


### PR DESCRIPTION
Popen in many versions of Python (possibly all versions prior to 3.3.1?) defaults to using unbuffered reads (bufsize=0), which are *extremely* slow. When reading a 160k file from git, unbuffered reads take 5.75s; buffered reads take 0.23s.

Newer versions of Python 3 appear to change the default to bufsize=-1 so this may only be a problem for a subset of users, but it certainly was a problem for me. I’m not sure of any reason not to just use buffered reads by default for everyone, so I am submitting this patch for evaluation. Thanks!